### PR TITLE
Units; remove not supported [portrait] code

### DIFF
--- a/units/Monster_Gryphlet.cfg
+++ b/units/Monster_Gryphlet.cfg
@@ -17,18 +17,6 @@
     undead_variation=gryphon
     description= _ "Juvenile grypons are covered with white and gray feathers, softer and more luxurious than those of their adult relatives. By the time they learn to fly, most have already grown larger than a wolf, and are more than capable of defending their nests from intruders."
     die_sound={SOUND_LIST:GRYPHON_DIE}
-    [portrait]
-        size=400
-        side="left"
-        mirror="false"
-        image="portraits/monsters/gryphon.png"
-    [/portrait]
-    [portrait]
-        size=400
-        side="right"
-        mirror="true"
-        image="portraits/monsters/gryphon.png"
-    [/portrait]
     [defense]
         mountains=40
     [/defense]


### PR DESCRIPTION
Removed `[portrait]`. It has not been supported since 1.14