### PR TITLE
Lua: fix companion message fallback

### DIFF
--- a/lua/companion_message.lua
+++ b/lua/companion_message.lua
@@ -68,6 +68,6 @@ function wesnoth.wml_actions.companion_message(cfg)
 	-- FALLBACK TO KONRAD
 	--###########################
 	local speaker_id = "Konrad"
-	if (cfg["message_"..speaker_id]) then wesnoth.wml_actions.message{ speaker=speaker_id, message=cfg["message_"..speaker_id] } end
+	if (cfg["fallback_"..speaker_id]) then wesnoth.wml_actions.message{ speaker=speaker_id, message=cfg["fallback_"..speaker_id] } end
 	return
 end


### PR DESCRIPTION
In the campaign the fallback message by Konrad is given as `fallback_Konrad=`
The code was checking for presence of `message_Konrad=` instead