### PR TITLE
make sptre of fire attack neutral(1.20 only and later)

### DIFF
--- a/utils/specials_and_abilities.cfg
+++ b/utils/specials_and_abilities.cfg
@@ -282,6 +282,7 @@
             icon=attacks/fireball.png
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
@@ -296,6 +297,7 @@
             icon=attacks/fireball.png
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
@@ -310,6 +312,7 @@
             icon=attacks/fireball.png
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
@@ -324,6 +327,7 @@
             icon=attacks/fireball.png
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]


### PR DESCRIPTION
Konrad is alignment lawful and Li'sar neutral, but the speter is so powerful that for them the difficulty comes more from keeping control in combat than trying to go to the maximum unlike the sword which comes from training, or from the magical mastery of mage which also comes with years of practice. For me, the fact that the speter is of reduced power at level 1 comes from the fact that the wearer lacks confidence and unconsciously restrains the power of the artifact. In the end, I consider that the alignment does not come into play because Konrad should not be more comfortable during the day than at night to handle what is a monster of power.