### PR TITLE
fix test of the clans scenarios/47_Test_of_the_Clans

### DIFF
--- a/scenarios/47_Test_of_the_Clans.cfg
+++ b/scenarios/47_Test_of_the_Clans.cfg
@@ -8,7 +8,7 @@
 [scenario]
     name=_"scenario name^Test of the Clans"
     {MAP_DYNAMIC 47_Test_of_the_Clans}
-    next_scenario,victory_when_enemies_defeated=00_The_Great_Continent,no
+    next_scenario,victory_when_enemies_defeated=00_The_Great_Continent,yes
     {SCHEDULE_DYNAMIC_DAY OFFSET={TOD_OFFSET}}
     turns=-1
           {SCENARIO_MUSIC loyalists.ogg}
@@ -445,6 +445,10 @@ I will promise you this, however. If your forces can defeat me in battle, I myse
     #############################
     # VICTORY
     #############################
+    [event]
+        name=enemies defeated
+        {FIRE_EVENT victory_cutscene}
+    [/event]
     [event]
         name=victory_cutscene
         {MODIFY_UNIT id=Bayar role clanboss}


### PR DESCRIPTION
If, against all odds, all the leaders were defeated before there were enough enemies to defeat on the map, maintaining this quota at all costs would block the game and condemn the player to defeat.