### PR TITLE
use abilities used in distance for Li'sar(wesnoth 1.19.15 andlater)

### DIFF
--- a/utils/specials_and_abilities.cfg
+++ b/utils/specials_and_abilities.cfg
@@ -12,7 +12,56 @@
         id,name=exacting,_"exacting"
         description= _ "Li’sar has drilled her infantry to perfection. Though few in number, each of her soldiers possesses skills not usually seen on others of their type."
     [/dummy]
+#textdomain wesnoth-help
+    [damage]
+        id=exacting_backstab
+        name_affected= _ "backstab"
+        description_affected= _ "When used offensively, this attack deals double damage if there is an enemy of the target on the opposite side of the target, and that unit is not incapacitated (turned to stone or otherwise paralyzed)."
+        multiply=2
+        active_on=offense
+        affect_self=no
+        [filter_student]
+            [filter_weapon]
+                range=melee
+            [/filter_weapon]
+        [/filter_student]
+        [filter_opponent]
+            formula="
+                enemy_of(self, flanker) and not flanker.petrified
+            where
+                flanker = unit_at(direction_from(loc, other.facing))
+            "
+        [/filter_opponent]
+        [affect_adjacent]
+            radius=all_map
+            [filter]
+                type_adv_tree=Fencer
+            [/filter]
+        [/affect_adjacent]
+    [/damage]
+    [chance_to_hit]
+        id=exacting_marksman
+        description_affected= _ "When used offensively, this attack always has at least a 60% chance to hit."
+        value=60
+        cumulative=yes
+        active_on=offense
+        name_affected=_"marksman"
+        affect_self=no
+        [filter_student]
+            [filter_weapon]
+                range=ranged
+            [/filter_weapon]
+        [/filter_student]
+        [affect_adjacent]
+            radius=all_map
+            [filter]
+                type_adv_tree=Bowman
+            [/filter]
+        [/affect_adjacent]
+    [/chance_to_hit]
 #enddef
+
+#textdomain wesnoth-h2tt
 
 #define MARCH_MOVEMENT
     # also used by Lisar
@@ -133,39 +182,7 @@
             )}
         )}
     [/event]
-    #------------------
-    # FENCER
-    #------------------
-    # backstabs on a fencer. Extremely strong
-    [event]
-        name,first_time_only=unit placed,no
-        {FILTER type_adv_tree=Fencer}
-        {FILTER_CONDITION( {HAVE_UNIT side,ability=$unit.side,exacting} )}
-        
-        {REMOVE_OBJECT exacting_object id=$unit.id}
-        {GIVE_OBJECT_TO id=$unit.id (id=exacting_object
-            {EFFECT attack (range=melee
-                [set_specials] mode=append {WEAPON_SPECIAL_BACKSTAB} [/set_specials]
-            )}
-        )}
-    [/event]
-    #------------------
-    # BOWMAN
-    #------------------
-    # marksman is useful, but not nearly as extreme as HI/fencers
-    [event]
-        name,first_time_only=unit placed,no
-        {FILTER type_adv_tree=Bowman}
-        {FILTER_CONDITION( {HAVE_UNIT side,ability=$unit.side,exacting} )}
-        
-        {REMOVE_OBJECT exacting_object id=$unit.id}
-        {GIVE_OBJECT_TO id=$unit.id (id=exacting_object
-            {EFFECT attack (range=ranged
-                [set_specials] mode=append {WEAPON_SPECIAL_MARKSMAN} [/set_specials] )}
-        )}
-    [/event]
 #enddef
-
 #############################
 # MOREMIRMU
 #############################


### PR DESCRIPTION
Using object type modifications on a large number of units can affect performance, hence the idea of ​​using abilities that act on the entire map as much as possible instead. i already proposed that, and this pR will be remain todraft until stable version